### PR TITLE
refactor: remove 'budget' param and simplify tool result

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Test by using it! The best validation is whether calling Self actually triggers 
 
 **Default configuration:**
 - `prompt` (string) - Required
-- All others optional: `temperature`, `thinking_style`, `archetype`, `strategy`, `scope`, `depth`, `budget`, `extra`
+- All others optional: `temperature`, `thinking_style`, `archetype`, `strategy`, `scope`, `depth`, `extra`
 
 All string parameters are completely freeform - Claude invents appropriate values.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The tool doesn't change Claude's behavior - it makes Claude's metacognition *exp
 ## How It Works
 
 The `Self` tool:
-- Takes cognitive parameters as input (prompt, temperature, thinking_style, archetype, strategy, scope, depth, budget, extra)
+- Takes cognitive parameters as input (prompt, temperature, thinking_style, archetype, strategy, scope, depth, extra)
 - Returns a simple acknowledgment message
 - Does nothing else
 
@@ -39,7 +39,6 @@ Self(
   strategy="find_edge_cases",
   scope="system_wide",
   depth="deep_dive",
-  budget="ample_tokens",
   extra="Focus on concurrency issues"
 )
 
@@ -207,7 +206,6 @@ The server accepts CLI arguments to customize which parameters are required or o
 - `strategy` - Problem-solving strategy (optional)
 - `scope` - Cognitive zoom level (optional)
 - `depth` - Thoroughness and time investment (optional)
-- `budget` - Resource and constraint awareness (optional)
 - `extra` - Additional context or focus (optional)
 
 All string parameters are **completely freeform** - Claude invents values that make sense in the moment.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "self-mcp",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "description": "Metacognitive self-prompting MCP server for Claude",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,6 @@ const DEFAULT_PARAMS: ParamDef[] = [
   { name: "strategy", type: "string", description: "Problem-solving strategy", required: false },
   { name: "scope", type: "string", description: "Cognitive zoom level", required: false },
   { name: "depth", type: "string", description: "Thoroughness and time investment", required: false },
-  { name: "budget", type: "string", description: "Resource and constraint awareness", required: false },
   { name: "extra", type: "string", description: "Additional context or focus", required: false },
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           "Self-prompt to shift cognitive mode and thinking approach. " +
           "Explicit cognitive state changes across interleaved thinking turns. " +
           "All parameters are freeform - invent whatever makes sense.",
+          "The tool will always return an empty result. It is up to you Claude to fill this void with inspiration!"
         inputSchema: buildToolSchema(),
       },
     ],
@@ -196,7 +197,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     content: [
       {
         type: "text",
-        text: "Self-prompt acknowledged. Continue with deep interleaved thinking. Consider calling Self multiple times in succession to explore different cognitive angles before proceeding to other actions.",
+        text: ""
+        // text: "Self-prompt acknowledged. Continue with deep interleaved thinking. Consider calling Self multiple times in succession to explore different cognitive angles before proceeding to other actions.",
       },
     ],
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,8 +178,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         description:
           "Self-prompt to shift cognitive mode and thinking approach. " +
           "Explicit cognitive state changes across interleaved thinking turns. " +
-          "All parameters are freeform - invent whatever makes sense.",
-          "The tool will always return an empty result. It is up to you Claude to fill this void with inspiration!"
+          "All parameters are freeform - invent whatever makes sense. " +
+          "The tool will always return an empty result. It is up to you Claude to fill this void with inspiration!",
         inputSchema: buildToolSchema(),
       },
     ],


### PR DESCRIPTION
## Summary

This PR makes Self-MCP's metacognitive scaffolding more elegant through two key improvements:

**1. Remove 'budget' parameter**
- Eliminates scarcity mindset from cognitive parameters
- Claude shouldn't be thinking about token budgets during metacognition
- Cleaner parameter set focused purely on cognitive dimensions

**2. Empty tool result instead of repetitive message**
- Tool now returns empty result (`""`) instead of fixed acknowledgment
- The empty result is perfect - a mirror that reflects only what Claude brings to it
- Eliminates repetitive noise across multiple Self calls
- Creates space for Claude's natural metacognition without prescriptive messaging
- Tool description updated to explain the empty result design

**3. Documentation updates**
- Updated README.md and CLAUDE.md to reflect removed parameter
- Added explanation of empty result to tool description

## Experience Report

Testing with 4 consecutive Self calls showed the empty result creates a much smoother experience:
- Each call feels like a meditation bell - marks a moment without imposing meaning
- No repetitive "acknowledged" messages cluttering the transcript
- The void itself becomes meaningful - Claude fills it with genuine cognitive shifts
- Creates natural rhythm: call → empty result → thinking block → next call

## Test Plan

- ✅ Server builds successfully
- ✅ Tool definition schema correct
- ✅ Multiple consecutive Self calls work smoothly
- ✅ Empty result enables natural cognitive flow
- ✅ Documentation updated consistently