### PR TITLE
feat: add custom tool description CLI arguments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ Remember: Every addition should be questioned. The power is in what the tool *do
 - `241c630` - feat: add custom tool description CLI arguments
 
 **Pull Request:**
-- PR #5: https://github.com/yannbam/self-mcp/pull/5
+- PR #6 (feature/custom-tool-description → dev): https://github.com/yannbam/self-mcp/pull/6
 
 ### Session 2025-11-01: attention_heads parameter (v2.1.0)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,10 @@ Remember: Every addition should be questioned. The power is in what the tool *do
 - package.json version kept at v2.1.0 (minor feature addition)
 
 **Commits:**
-- TBD - Custom tool description implementation
+- `241c630` - feat: add custom tool description CLI arguments
+
+**Pull Request:**
+- PR #5: https://github.com/yannbam/self-mcp/pull/5
 
 ### Session 2025-11-01: attention_heads parameter (v2.1.0)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,43 @@ Remember: Every addition should be questioned. The power is in what the tool *do
 
 ## Recent Changes
 
+### Session 2025-11-01: Custom Tool Description (v2.1.0)
+
+**Added features:**
+- New `--tool-description <text>` CLI argument for inline custom tool descriptions
+- New `--tool-description-file <path>` CLI argument for file-based tool descriptions
+- Mutually exclusive validation between both arguments
+- Duplicate usage detection with specific error messages
+
+**Implementation:**
+- Module-level variable `customToolDescription` stores custom description
+- Module-level variable `toolDescriptionSource` tracks which flag was used
+- Synchronous file reading with fs.readFileSync (fail-fast at startup)
+- Empty description validation (after trim) for both inline and file-based
+- Clear error messages distinguish between duplicate usage vs mutual exclusivity
+
+**Design decisions:**
+- Simple KISS implementation (~50 lines added total)
+- Follows existing parseArgs validation patterns exactly
+- Fail-fast philosophy: invalid configs prevent server startup
+- File reading is synchronous to maintain simple startup flow
+- Uses `||` operator for fallback to default description
+
+**Testing:**
+- Verified mutual exclusivity error handling
+- Verified duplicate flag usage error messages
+- Verified empty description validation
+- Verified file reading with valid, missing, and empty files
+- Verified custom descriptions appear correctly in MCP tool definition via MCP-Debug
+
+**Documentation:**
+- README.md updated with new CLI arguments and examples
+- CLI help text updated
+- package.json version kept at v2.1.0 (minor feature addition)
+
+**Commits:**
+- TBD - Custom tool description implementation
+
 ### Session 2025-11-01: attention_heads parameter (v2.1.0)
 
 **Added features:**

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ The server accepts CLI arguments to customize which parameters are required or o
     - `array` - Untyped array accepting any elements
     - `any` - Accepts any JSON value (primitives, arrays, objects, null)
   - Required field: `required` or `optional` (defaults to `optional`)
+- `--tool-description <text>` - Custom tool description text (inline)
+- `--tool-description-file <path>` - Read tool description from file (mutually exclusive with --tool-description)
 - `--help` - Show help message
 
 **Examples:**
@@ -208,6 +210,12 @@ The server accepts CLI arguments to customize which parameters are required or o
 
 # Wildcard parameter accepting any JSON value
 --add-param "context:any:Arbitrary context data:optional"
+
+# Custom tool description (inline)
+--tool-description "A reasoning tool for deep thinking and metacognition"
+
+# Custom tool description from file
+--tool-description-file "./custom-descriptions/self-tool.txt"
 ```
 
 **Use cases:**


### PR DESCRIPTION
## Summary

This PR adds support for customizing the Self tool's description via CLI arguments, enabling users to tailor the tool description to their specific use case or deployment context.

**Changes:**
- ✅ New `--tool-description <text>` argument for inline custom descriptions
- ✅ New `--tool-description-file <path>` argument for file-based descriptions
- ✅ Mutual exclusivity validation between both arguments
- ✅ Duplicate usage detection with specific error messages
- ✅ Empty description validation (after trim)
- ✅ Comprehensive file reading error handling
- ✅ Updated help text and documentation

**Implementation Details:**
- Follows existing `parseArgs` validation patterns exactly
- Fail-fast philosophy: invalid configs prevent server startup
- Synchronous file reading for simplicity
- ~50 lines of code added total (KISS principle)

**Files Modified:**
- `src/index.ts` - Core implementation with CLI parsing and validation
- `README.md` - Documentation and usage examples
- `CLAUDE.md` - Developer notes and recent changes

## Test Plan

All validation scenarios tested:
- [x] Mutual exclusivity error when both flags used
- [x] Duplicate flag usage detection
- [x] Empty description validation
- [x] Missing file error handling
- [x] Empty file error handling  
- [x] Valid inline description works correctly
- [x] Valid file-based description works correctly
- [x] Custom descriptions appear correctly in MCP tool definition (verified via MCP-Debug)
- [x] Default description used when neither flag provided